### PR TITLE
Add two extra fields for each class

### DIFF
--- a/bench-field.pl
+++ b/bench-field.pl
@@ -29,8 +29,13 @@ use Foo;
 # This logic is accessing to object field many times.
 sub create_main_logic_coderef($benchmark_class) {
     return sub {
-        state $object = $benchmark_class->new(foo => 'foo!');
-        $object->foo for 1..100;
+        state $object = $benchmark_class->new(
+            foo => 'foo!',
+            bar => 'bar?',
+            baz => 'baz.',
+        );
+        $object->foo for 1..50;
+        $object->baz for 1..50;
     }
 }
 

--- a/bench-new.pl
+++ b/bench-new.pl
@@ -30,9 +30,14 @@ use Foo;
 sub create_main_logic_coderef($benchmark_class) {
     return sub {
         for (1..1000) {
-            my $f = $benchmark_class->new(foo => 'foo' . $_);
+            my $f = $benchmark_class->new(
+                foo => 'foo' . $_,
+                bar => 'bar' . $_,
+                baz => 'baz' . $_,
+            );
         }
     }
 }
 
 Foo::run_benchmark(\&create_main_logic_coderef);
+

--- a/bench-size.pl
+++ b/bench-size.pl
@@ -29,9 +29,16 @@ use Foo;
 # This logic is creaing a list consists of many objects.
 sub create_main_logic_coderef($benchmark_class) {
     return sub {
-        my @list = map { $benchmark_class->new(foo => 'foo' . $_) } 1 .. 1000;
+        my @list = map {
+            $benchmark_class->new(
+                foo => 'foo' . $_,
+                bar => 'bar' . $_,
+                baz => 'baz' . $_,
+            )
+        } 1 .. 1000;
         return \@list;
     }
 }
 
 Foo::run_memory_consumption_benchmark(\&create_main_logic_coderef);
+

--- a/lib/Foo/Bless.pm
+++ b/lib/Foo/Bless.pm
@@ -9,4 +9,13 @@ package Foo::Bless {
     sub foo($self) {
         $self->{foo}
     }
+
+    sub bar($self) {
+        $self->{bar}
+    }
+
+    sub baz($self) {
+        $self->{baz}
+    }
 }
+

--- a/lib/Foo/BlessArray.pm
+++ b/lib/Foo/BlessArray.pm
@@ -3,10 +3,19 @@ use v5.38;
 package Foo::BlessArray {
     sub new {
         my ($class, %args) = @_;
-        bless [ $args{foo} ], $class;
+        bless [ @args{qw(foo bar baz)} ], $class;
     }
 
     sub foo($self) {
         $self->[0]
     }
+
+    sub bar($self) {
+        $self->[1]
+    }
+
+    sub baz($self) {
+        $self->[2]
+    }
 }
+

--- a/lib/Foo/ClassAccessorLite.pm
+++ b/lib/Foo/ClassAccessorLite.pm
@@ -3,6 +3,7 @@ use v5.38;
 package Foo::ClassAccessorLite {
     use Class::Accessor::Lite (
         new => 1,
-        ro  => [qw(foo)],
+        ro  => [qw(foo bar baz)],
     );
 }
+

--- a/lib/Foo/ClassTiny.pm
+++ b/lib/Foo/ClassTiny.pm
@@ -1,5 +1,6 @@
 use v5.38;
 
 package Foo::ClassTiny {
-    use Class::Tiny qw(foo);
+    use Class::Tiny qw(foo bar baz);
 }
+

--- a/lib/Foo/FeatureClass.pm
+++ b/lib/Foo/FeatureClass.pm
@@ -3,6 +3,11 @@ use experimental qw(class);
 
 class Foo::FeatureClass {
     field $foo :param;
+    field $bar :param;
+    field $baz :param;
 
     method foo() { $foo }
+    method bar() { $bar }
+    method baz() { $baz }
 };
+

--- a/lib/Foo/Moo.pm
+++ b/lib/Foo/Moo.pm
@@ -4,4 +4,7 @@ package Foo::Moo {
     use Moo;
 
     has foo => (is => 'ro');
+    has bar => (is => 'ro');
+    has baz => (is => 'ro');
 }
+

--- a/lib/Foo/Moose.pm
+++ b/lib/Foo/Moose.pm
@@ -4,4 +4,7 @@ package Foo::Moose {
     use Moose;
 
     has foo => (is => 'ro');
+    has bar => (is => 'ro');
+    has baz => (is => 'ro');
 }
+

--- a/lib/Foo/Mouse.pm
+++ b/lib/Foo/Mouse.pm
@@ -4,4 +4,7 @@ package Foo::Mouse {
     use Mouse;
 
     has foo => (is => 'ro');
+    has bar => (is => 'ro');
+    has baz => (is => 'ro');
 }
+

--- a/lib/Foo/ObjectPad.pm
+++ b/lib/Foo/ObjectPad.pm
@@ -3,4 +3,7 @@ use Object::Pad;
 
 class Foo::ObjectPad {
     field $foo :param :reader;
+    field $bar :param :reader;
+    field $baz :param :reader;
 };
+

--- a/lib/Foo/ObjectTiny.pm
+++ b/lib/Foo/ObjectTiny.pm
@@ -1,5 +1,6 @@
 use v5.38;
 
 package Foo::ObjectTiny {
-    use Object::Tiny qw(foo);
+    use Object::Tiny qw(foo bar baz);
 }
+


### PR DESCRIPTION
Benchmarking a single field may give results favouring simple but not very scalable solutions. Three fields should be more similar to common classes used in software.