### PR TITLE
Add XS variants for Moose and Moo

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -5,5 +5,7 @@ requires 'Moo';
 requires 'Moose';
 requires 'Class::Tiny';
 requires 'Object::Tiny';
+requires 'MooseX::XSAccessor';
 
 requires 'Devel::Size';
+

--- a/cpanfile
+++ b/cpanfile
@@ -6,6 +6,7 @@ requires 'Moose';
 requires 'Class::Tiny';
 requires 'Object::Tiny';
 requires 'MooseX::XSAccessor';
+requires 'MooX::XSConstructor';
 
 requires 'Devel::Size';
 

--- a/lib/Foo.pm
+++ b/lib/Foo.pm
@@ -9,6 +9,7 @@ package Foo {
     use Foo::ClassAccessorLite;
     use Foo::Mouse;
     use Foo::Moose;
+    use Foo::MooseXS;
     use Foo::Moo;
     use Foo::ClassTiny;
     use Foo::ObjectTiny;
@@ -22,6 +23,7 @@ package Foo {
         'Foo::Mouse'             => sprintf('`Mouse@%s`', Mouse->VERSION),
         'Foo::Moo'               => sprintf('`Moo@%s`', Moo->VERSION),
         'Foo::Moose'             => sprintf('`Moose@%s`', Moose->VERSION),
+        'Foo::MooseXS'           => sprintf('`Moose@%s (XSAccessor)`', Moose->VERSION),
         'Foo::ClassTiny'         => sprintf('`Class::Tiny@%s`', Class::Tiny->VERSION),
         'Foo::ObjectTiny'        => sprintf('`Object::Tiny@%s`', Object::Tiny->VERSION),
         'Foo::Bless'             => '`bless hashref`',
@@ -88,3 +90,4 @@ package Foo {
         }
     }
 }
+

--- a/lib/Foo.pm
+++ b/lib/Foo.pm
@@ -11,6 +11,7 @@ package Foo {
     use Foo::Moose;
     use Foo::MooseXS;
     use Foo::Moo;
+    use Foo::MooXS;
     use Foo::ClassTiny;
     use Foo::ObjectTiny;
     use Foo::Bless;
@@ -22,6 +23,7 @@ package Foo {
         'Foo::ClassAccessorLite' => sprintf('`Class::Accessor::Lite@%s`', Class::Accessor::Lite->VERSION),
         'Foo::Mouse'             => sprintf('`Mouse@%s`', Mouse->VERSION),
         'Foo::Moo'               => sprintf('`Moo@%s`', Moo->VERSION),
+        'Foo::MooXS'             => sprintf('`Moo@%s (XSConstructor + XSAccessor)`', Moo->VERSION),
         'Foo::Moose'             => sprintf('`Moose@%s`', Moose->VERSION),
         'Foo::MooseXS'           => sprintf('`Moose@%s (XSAccessor)`', Moose->VERSION),
         'Foo::ClassTiny'         => sprintf('`Class::Tiny@%s`', Class::Tiny->VERSION),

--- a/lib/Foo/Moo.pm
+++ b/lib/Foo/Moo.pm
@@ -1,5 +1,7 @@
 use v5.38;
 
+$ENV{MOO_XS_DISABLE} = 1;
+
 package Foo::Moo {
     use Moo;
 
@@ -7,4 +9,6 @@ package Foo::Moo {
     has bar => (is => 'ro');
     has baz => (is => 'ro');
 }
+
+undef $ENV{MOO_XS_DISABLE};
 

--- a/lib/Foo/MooXS.pm
+++ b/lib/Foo/MooXS.pm
@@ -2,11 +2,12 @@ use v5.38;
 
 BEGIN {
     use Method::Generate::Accessor;
-    $Method::Generate::Accessor::CAN_HAZ_XS = 0;
+    $Method::Generate::Accessor::CAN_HAZ_XS = 1;
 }
 
-package Foo::Moo {
+package Foo::MooXS {
     use Moo;
+    use MooX::XSConstructor;
 
     has foo => (is => 'ro');
     has bar => (is => 'ro');

--- a/lib/Foo/MooseXS.pm
+++ b/lib/Foo/MooseXS.pm
@@ -1,0 +1,13 @@
+use v5.38;
+
+package Foo::MooseXS {
+    use Moose;
+    use MooseX::XSAccessor;
+
+    has foo => (is => 'ro');
+    has bar => (is => 'ro');
+    has baz => (is => 'ro');
+
+    __PACKAGE__->meta->make_immutable;
+}
+


### PR DESCRIPTION
Optional modules exist which add some XS boost to Moose and Moo. Some hackery is required for pure-perl Moo benchmark not to use XS when Class::XSAccessor is available.